### PR TITLE
Call ok_with method after successful experiment

### DIFF
--- a/lib/fast.rb
+++ b/lib/fast.rb
@@ -530,7 +530,7 @@ module Fast
       File.open(experimental_file, 'w+') { |f| f.puts content }
 
       if experiment.ok_if.call(experimental_file)
-        ok(combination)
+        ok_with(combination)
         puts "✅ #{combination} #{experimental_file}"
       else
         failed_with(combination)


### PR DESCRIPTION
Call the `ok_with` method instead of `ok`, which is not defined.

I assume this just fixes a typo 😄 