### PR TITLE
Update gemspec

### DIFF
--- a/fast.gemspec
+++ b/fast.gemspec
@@ -4,6 +4,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "ffast"
   spec.version       = '0.0.1'
+  spec.required_ruby_version = '>= 2.3'
   spec.authors       = ["Jônatas Davi Paganini"]
   spec.email         = ["jonatas.paganini@toptal.com"]
 

--- a/fast.gemspec
+++ b/fast.gemspec
@@ -1,10 +1,9 @@
 # coding: utf-8
 
-
 Gem::Specification.new do |spec|
   spec.name          = "ffast"
-  spec.version       = '0.0.1'
-  spec.required_ruby_version = '>= 2.3'
+  spec.version       = "0.0.1"
+  spec.required_ruby_version = ">= 2.3"
   spec.authors       = ["Jônatas Davi Paganini"]
   spec.email         = ["jonatas.paganini@toptal.com"]
 
@@ -16,13 +15,13 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "bin"
-  spec.executables   = ['fast']
+  spec.executables   = ["fast"]
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency "parser", "~> 2.4.0.0"
-  spec.add_dependency 'coderay', '~> 1.1.1'
+  spec.add_dependency "coderay", "~> 1.1.1"
   spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
I was getting a syntax error on the safe navigation operator (`&.`) in a project because I wasn't using Ruby >= 2.3.

```
2.1.6 :001 > require "fast"
SyntaxError: ~HOME/.rvm/gems/ruby-2.1.6/gems/ffast-0.0.1/lib/fast.rb:91: syntax error, unexpected '.'
    res&.size == 1 ? res[0] : res
         ^
	from ~HOME/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
	from ~HOME/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
	from ~HOME/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from (irb):1
	from ~HOME/.rvm/rubies/ruby-2.1.6/bin/irb:11:in `<main>'
```

This should at least expose that requirement.