### PR TITLE
Standardize public methods interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ It's corresponding s-expression would be:
 If we wanted to find this particular assignment somewhere in our AST, we can use
 Fast to look for a local variable named `value` with a value `42`:
 
-    Fast.match?(ast, '(lvasgn value (int 42))') # => true
+    Fast.match? '(lvasgn value (int 42))', ast # => true
 
 ### Wildcard Token
 
 If we wanted to find a variable named `value` that was assigned any integer value
 we could replace `42` in our query with an underscore ( `_` ) as a shortcut:
 
-    Fast.match?(ast, '(lvasgn value (int _))') # => true
+    Fast.match? '(lvasgn value (int _))', ast # => true
 
 ### Set Inclusion Token
 
@@ -94,7 +94,7 @@ If we weren't sure the type of the value we're assigning, we can use our set
 inclusion token (`{}`) from earlier to tell Fast that we expect either a `Float`
 or an `Integer`:
 
-    Fast.match?(ast, '(lvasgn value ({float int} _))') # => true
+    Fast.match? '(lvasgn value ({float int} _))', ast # => true
 
 ### All Matching Token
 
@@ -103,17 +103,17 @@ all matching token (`[]`) to express multiple conditions that need to be true.
 In this case we don't want the value to be a `String`, `Hash`, or an `Array` by
 prefixing all of the types with `!`:
 
-    Fast.match?(ast, '(lvasgn value ([!str !hash !array] _))') # => true
+    Fast.match? '(lvasgn value ([!str !hash !array] _))', ast # => true
 
 ### Node Child Token
 
 We can match any node with children by using the child token ( `...` ):
 
-    Fast.match?(ast, '(lvasgn value ...)') # => true
+    Fast.match? '(lvasgn value ...)', ast # => true
 
 We could even match any local variable assignment combining both `_` and `...`:
 
-    Fast.match?(ast, '(lvasgn _ ...)') # => true
+    Fast.match? '(lvasgn _ ...)', ast # => true
 
 ### Capturing the Value of an Expression
 
@@ -142,7 +142,7 @@ method names and guarantee they are unique.
       already_exists
     end
 
-    puts Fast.search_file( '(def #duplicated)', 'example.rb')
+    puts Fast.search_file('(def #duplicated)', 'example.rb')
 
 The same principle can be used in the node level or for debugging purposes.
 
@@ -195,9 +195,8 @@ a single `Object`, like `a.b.c.d`. Its corresponding s-expression would be:
 You can also search using nested arrays with **pure values**, or **shortcuts** or
 **procs**:
 
-    Fast.match?(ast, [:send, [:send, '...'], :d]) # => true
-    Fast.match?(ast, [:send, [:send, '...'], :c]) # => false
-    Fast.match?(ast, [:send, [:send, [:send, '...'], :c], :d]) # => true
+    Fast.match? ast, [:send, [:send, '...'], :d]  # => true
+    Fast.match? ast, [:send, [:send, '...'], :c]  # => false
 
 Shortcut tokens like child nodes `...` and wildcards `_` are just placeholders
 for procs. If you want, you can even use procs directly like so:
@@ -223,7 +222,7 @@ This also works with expressions:
 If you find that a particular expression isn't working, you can use `debug` to
 take a look at what Fast is doing:
 
-    Fast.debug { Fast.match?(s(:int, 1), [:int, 1]) }
+    Fast.debug { Fast.match?(s(:int, 1), [:int, 1])  }
 
 Each comparison made while searching will be logged to your console (STDOUT) as
 Fast goes through the AST:
@@ -237,7 +236,7 @@ We can also dynamically interpolate arguments into our queries using the
 interpolation token `%`. This works much like `sprintf` using indexes starting
 from `1`:
 
-    Fast.match?(code('a = 1'), '(lvasgn %1 (int _))', :a) # => true
+    Fast.match? :a, code('a = 1'), '(lvasgn %1 (int _))' # => true
 
 ## Using previous captures in search
 
@@ -360,7 +359,7 @@ To refactor and reach the proposed example, follow a few steps:
 #### Entire example
 
     assignment = nil
-    Fast.replace_file 'sample.rb', '({ lvasgn lvar } message )', -> (node, _) {
+    Fast.replace_file '({ lvasgn lvar } message )', 'sample.rb' do |node, _|
       # Find a variable assignment
       if node.type == :lvasgn
         assignment = node.children.last
@@ -466,7 +465,7 @@ and add the snippet to your library fixing the filename.
 
 ```ruby
 Fast.shortcut :bump_version do
-  rewrite_file('lib/fast/version.rb', '(casgn nil VERSION (str _)') do |node|
+  rewrite_file('(casgn nil VERSION (str _)', 'lib/fast/version.rb') do |node|
     target = node.children.last.loc.expression
     pieces = target.source.split(".").map(&:to_i)
     pieces.reverse.each_with_index do |fragment,i|

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -35,12 +35,8 @@ Getting all `it` blocks without description:
 
 ```ruby
 # spec/fast_spec.rb:166
-it { expect(described_class).to be_match(s(:int, 1), '(...)') }
-# spec/fast_spec.rb:167
-it { expect(described_class).to be_match(s(:int, 1), '(_ _)') }
-# spec/fast_spec.rb:168
-it { expect(described_class).to be_match(code['"string"'], '(str "string")') }
-# ... more results
+it { expect(described_class).to be_match('(...)', s(:int, 1)) }
+...
 ```
 
 ## `--debug`

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -6,7 +6,6 @@ and you can use it to search and find code using the concept:
 ```
 $ fast '(def match?)' lib/fast.rb
 ```
-
 - Use `-d` or `--debug` for enable debug mode.
 - Use `--ast` to output the AST instead of the original code
 - Use `--pry` to jump debugging the first result with pry
@@ -118,12 +117,12 @@ You can define a `Fastfile` in any project with your custom shortcuts and easy
 check some code or run some task.
 
 
-## Shortcuts
+## Shortcut examples
 
 Create shortcuts with blocks enables introduce custom coding in
 the scope of the `Fast` module.
 
-## Example: Print library version.
+### Print library version.
 
 Let's say you'd like to show the version of your library. Your regular params
 in the command line will look like:
@@ -148,7 +147,7 @@ We can also always override the files params passing some other target file
 like `fast .version lib/other/file.rb` and it will reuse the other arguments
 from command line but replace the target files.
 
-### Example: Bumping a gem version
+### Bumping a gem version
 
 While releasing a new gem version, we always need to mechanical go through the
 `lib/<your_gem>/version.rb` and change the string value to bump the version

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,25 +107,25 @@ ast = s(:lvasgn, :value, s(:int, 42))
 Now, lets find local variable named `value` with an value `42`:
 
 ```ruby
-Fast.match?(ast, '(lvasgn value (int 42))') # true
+Fast.match?('(lvasgn value (int 42))', ast) # true
 ```
 
 Lets abstract a bit and allow some integer value using `_` as a shortcut:
 
 ```ruby
-Fast.match?(ast, '(lvasgn value (int _))') # true
+Fast.match?('(lvasgn value (int _))', ast) # true
 ```
 
 Lets abstract more and allow float or integer:
 
 ```ruby
-Fast.match?(ast, '(lvasgn value ({float int} _))') # true
+Fast.match?('(lvasgn value ({float int} _))', ast) # true
 ```
 
 Or combine multiple assertions using `[]` to join conditions:
 
 ```ruby
-Fast.match?(ast, '(lvasgn value ([!str !hash !array] _))') # true
+Fast.match?('(lvasgn value ([!str !hash !array] _))', ast) # true
 ```
 
 Matches all local variables not string **and** not hash **and** not array.
@@ -133,25 +133,25 @@ Matches all local variables not string **and** not hash **and** not array.
 We can match "a node with children" using `...`:
 
 ```ruby
-Fast.match?(ast, '(lvasgn value ...)') # true
+Fast.match?('(lvasgn value ...)', ast) # true
 ```
 
 You can use `$` to capture a node:
 
 ```ruby
-Fast.match?(ast, '(lvasgn value $...)') # => [s(:int, 42)]
+Fast.match?(ast, '(lvasgn value $...)') # => [s(:int), 42]
 ```
 
 Or match whatever local variable assignment combining both `_` and `...`:
 
 ```ruby
-Fast.match?(ast, '(lvasgn _ ...)') # true
+Fast.match?('(lvasgn _ ...)', ast) # true
 ```
 
 You can also use captures in any levels you want:
 
 ```ruby
-Fast.match?(ast, '(lvasgn $_ $...)') # [:value, s(:int, 42)]
+Fast.match?('(lvasgn $_ $...)', ast) # [:value, s(:int), 42]
 ```
 
 Keep in mind that `_` means something not nil and `...` means a node with
@@ -220,7 +220,7 @@ Fast.match?(
 If something does not work you can debug with a block:
 
 ```ruby
-Fast.debug { Fast.match?(s(:int, 1), [:int, 1]) }
+Fast.debug { Fast.match?([:int, 1], s(:int, 1)) }
 ```
 
 It will output each comparison to stdout:

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,11 +81,11 @@ Fast.ast("b += 2")  # => s(:op_asgn, s(:lvasgn, :b), :+, s(:int, 2))
 It uses [astrolable](https://github.com/yujinakayama/astrolabe) gem behind the scenes:
 
 ```ruby
-Fast.ast(Fast.ast("1").class
+Fast.ast(Fast.ast("1")).class
 => Astrolabe::Node
-Fast.ast(Fast.ast("1").type
+Fast.ast(Fast.ast("1")).type
 => :int
-Fast.ast(Fast.ast("1").children
+Fast.ast(Fast.ast("1")).children
 => [1]
 ```
 
@@ -382,7 +382,7 @@ Combines the [search_file](#search_file) with [ruby_files_from](#ruby_files_from
 multiple locations and returns tuples with files and results.
 
 ```ruby
-Fast.search_all("(def ast_from_file")
+Fast.search_all("(def ast_from_file)")
 => {"./lib/fast.rb"=>[s(:def, :ast_from_file,
   s(:args,
     s(:arg, :file)),

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,9 +64,36 @@ The current version cover the following elements:
 
 Jump to [Syntax](syntax.md).
 
-## Fast.match?
+## ast
 
-`match?` is the most granular function that tries to compare a node with an
+Use `Fast.ast` to convert simple code to AST objects. You can use it as
+`ruby-parse` but directly from the console.
+
+```ruby
+Fast.ast("1")       # => s(:int, 1)
+Fast.ast("method")  # => s(:send, nil, :method)
+Fast.ast("a.b")     # => s(:send, s(:send, nil, :a), :b)
+Fast.ast("1 + 1")   # => s(:send, s(:int, 1), :+, s(:int, 1))
+Fast.ast("a = 2")   # => s(:lvasgn, :a, s(:int, 2))
+Fast.ast("b += 2")  # => s(:op_asgn, s(:lvasgn, :b), :+, s(:int, 2))
+```
+
+It uses [astrolable](https://github.com/yujinakayama/astrolabe) gem behind the scenes:
+
+```ruby
+Fast.ast(Fast.ast("1").class
+=> Astrolabe::Node
+Fast.ast(Fast.ast("1").type
+=> :int
+Fast.ast(Fast.ast("1").children
+=> [1]
+```
+
+See also [ast_from_file](#ast_from_file).
+
+## match?
+
+`Fast.match?` is the most granular function that tries to compare a node with an
 expression. It returns true or false and some node captures case it find
 something.
 
@@ -139,7 +166,7 @@ Fast.match?('(lvasgn value ...)', ast) # true
 You can use `$` to capture a node:
 
 ```ruby
-Fast.match?(ast, '(lvasgn value $...)') # => [s(:int), 42]
+Fast.match?('(lvasgn value $...)', ast) # => [s(:int), 42]
 ```
 
 Or match whatever local variable assignment combining both `_` and `...`:
@@ -196,25 +223,22 @@ You can search using sub-arrays with **pure values**, or **shortcuts** or
 **procs**:
 
 ```ruby
-Fast.match?(ast, [:send, [:send, '...'], :d]) # => true
-Fast.match?(ast, [:send, [:send, '...'], :c]) # => false
-Fast.match?(ast, [:send, [:send, [:send, '...'], :c], :d]) # => true
+Fast.match?([:send, [:send, '...'], :d], ast) # => true
+Fast.match?([:send, [:send, '...'], :c], ast) # => false
+Fast.match?([:send, [:send, [:send, '...'], :c], :d], ast) # => true
 ```
 
 Shortcuts like `...` and `_` are just literals for procs. Then you can use
 procs directly too:
 
 ```ruby
-Fast.match?(ast, [:send, [ -> (node) { node.type == :send }, [:send, '...'], :c], :d]) # => true
+Fast.match?([:send, [ -> (node) { node.type == :send }, [:send, '...'], :c], :d], ast) # => true
 ```
 
 And also work with expressions:
 
 ```ruby
-Fast.match?(
-  ast,
-  '(send (send (send (send nil $_) $_) $_) $_)'
-) # => [:a, :b, :c, :d]
+Fast.match?('(send (send (send (send nil $_) $_) $_) $_)', ast) # => [:a, :b, :c, :d]
 ```
 
 If something does not work you can debug with a block:
@@ -230,70 +254,40 @@ int == (int 1) # => true
 1 == 1 # => true
 ```
 
-## Use previous captures in search
-
-Imagine you're looking for a method that is just delegating something to
-another method, like:
-
-```ruby
-def name
-  person.name
-end
-```
-
-This can be represented as the following AST:
-
-```
-(def :name
-  (args)
-  (send
-    (send nil :person) :name))
-```
-
-Then, let's build a search for methods that calls an attribute with the same
-name:
-
-```ruby
-Fast.match?(ast,'(def $_ ... (send (send nil _) \1))') # => [:name]
-```
-
-## Fast.search
+## search
 
 Search allows you to go deeply in the AST, collecting nodes that matches with
 the expression. It also returns captures if they exist.
 
 ```ruby
-Fast.search(code('a = 1'), '(int _)') # => s(:int, 1)
+Fast.search('(int _)', Fast.ast('a = 1')) # => s(:int, 1)
 ```
 
 If you use captures, it returns the node and the captures respectively:
 
 ```ruby
-Fast.search(code('a = 1'), '(int $_)') # => [s(:int, 1), 1]
+Fast.search('(int $_)', Fast.ast('a = 1')) # => [s(:int, 1), 1]
 ```
 
-## Fast.capture
+## capture
 
 To pick just the captures and ignore the nodes, use `Fast.capture`:
 
 ```ruby
-Fast.capture(code('a = 1'), '(int $_)') # => 1
+Fast.capture('(int $_)', Fast.ast('a = 1')) # => 1
 ```
-## Fast.replace
+## replace
 
 And if I want to refactor a code and use `delegate <attribute>, to: <object>`, try with replace:
 
 ```ruby
-Fast.replace ast, '(def $_ ... (send (send nil $_) \1))' do |node, captures|
-    attribute, object = captures
-    replace(
-      node.location.expression,
-      "delegate :#{attribute}, to: :#{object}"
-    )
-  end
+Fast.replace '(def $_ ... (send (send nil $_) \1))', ast do |node, captures|
+  attribute, object = captures
+  replace(node.location.expression, "delegate :#{attribute}, to: :#{object}")
+end
 ```
 
-## Fast.replace_file
+## replace_file
 
 Now let's imagine we have real files like `sample.rb` with the following code:
 
@@ -312,19 +306,49 @@ is being called.
 
 ```ruby
 assignment = nil
-Fast.replace_file('sample.rb', '({ lvasgn lvar } message )',
-  -> (node, _) {
-    if node.type == :lvasgn
-      assignment = node.children.last
-      remove(node.location.expression)
-    elsif node.type == :lvar
-      replace(node.location.expression, assignment.location.expression.source)
-    end
-  }
-)
+Fast.replace_file('({ lvasgn lvar } message )','sample.rb')  do |node, _|
+  if node.type == :lvasgn
+    assignment = node.children.last
+    remove(node.location.expression)
+  elsif node.type == :lvar
+    replace(node.location.expression, assignment.location.expression.source)
+  end
+end
 ```
 
-## Fast.ast_from_File(file)
+It will return an output of the new source code with the changes but not save
+the file. You can use ()[#rewrite_file] if you're confident about the changes.
+
+## capture_file
+
+`Fast.capture_file` can be used to combine [capture](#capture) and file system.
+
+```ruby
+Fast.capture_file("$(casgn)", "lib/fast/version.rb") # => s(:casgn, nil, :VERSION, s(:str, "0.1.3"))
+Fast.capture_file("(casgn nil _ (str $_))", "lib/fast/version.rb") # => "0.1.3"
+```
+
+## capture_all
+
+`Fast.capture_all` can be used to combine [capture_file](#capture_file) from multiple sources:
+
+```ruby
+Fast.capture_all("(casgn nil $_)") # => { "./lib/fast/version.rb"=>:VERSION, "./lib/fast.rb"=>[:LITERAL, :TOKENIZER], ...}
+```
+
+The second parameter can also be passed with to filter specific folders:
+
+```ruby
+Fast.capture_all("(casgn nil $_)", "lib/fast") # => {"lib/fast/shortcut.rb"=>:LOOKUP_FAST_FILES_DIRECTORIES, "lib/fast/version.rb"=>:VERSION}
+```
+
+
+## rewrite_file
+
+`Fast.rewrite_file` works exactly as the `replace` but it will override the file
+from the input.
+
+## ast_from_file
 
 This method parses the code and load into a AST representation.
 
@@ -332,7 +356,7 @@ This method parses the code and load into a AST representation.
 Fast.ast_from_file('sample.rb')
 ```
 
-## Fast.search_file
+## search_file
 
 You can use `search_file` and pass the path for search for expressions inside
 files.
@@ -343,12 +367,31 @@ Fast.search_file(expression, 'file.rb')
 
 It's simple combination of `Fast.ast_from_file` with `Fast.search`.
 
-## Fast.ruby_files_from(arguments)
+## ruby_files_from
 
 You'll be probably looking for multiple ruby files, then this method fetches
 all internal `.rb` files 
 
 ```ruby
 Fast.ruby_files_from(['lib']) # => ["lib/fast.rb"]
+```
+
+## search_all
+
+Combines the [search_file](#search_file) with [ruby_files_from](#ruby_files_from)
+multiple locations and returns tuples with files and results.
+
+```ruby
+Fast.search_all("(def ast_from_file")
+=> {"./lib/fast.rb"=>[s(:def, :ast_from_file,
+  s(:args,
+    s(:arg, :file)),
+  s(:begin,
+```
+
+You can also override the second param and pass target files or folders:
+
+```ruby
+Fast.search_all("(def _)", '../other-folder')
 ```
 

--- a/docs/similarity_tutorial.md
+++ b/docs/similarity_tutorial.md
@@ -53,7 +53,7 @@ observe some specific node types and try to group the similarities
 using the pattern generated.
 
 ```ruby
-Fast.search_file('lib/fast.rb', 'class')
+Fast.search_file('class', 'lib/fast.rb')
 ```
 Capturing the constant name and filtering only for symbols is easy and we can
 see that we have a few classes defined in the the same file.

--- a/lib/fast.rb
+++ b/lib/fast.rb
@@ -677,12 +677,12 @@ module Fast
   # @example simple match
   #   ast = Fast.ast("a = 1")
   #   expression = Fast.expression("(lvasgn _ (int _))")
-  #   Matcher.new(ast,expression).match? # true
+  #   Matcher.new(expression, ast).match? # true
   #
   # @example simple capture
   #   ast = Fast.ast("a = 1")
   #   expression = Fast.expression("(lvasgn _ (int $_))")
-  #   Matcher.new(ast,expression).match? # => [1]
+  #   Matcher.new(expression, ast).match? # => [1]
   #
   class Matcher
     def initialize(pattern, ast, *args)
@@ -691,7 +691,7 @@ module Fast
                       Fast.expression(pattern)
                     else
                       [*pattern].map(&Find.method(:new))
-              end
+                    end
       @captures = []
       prepare_arguments(@expression, args) if args.any?
     end

--- a/lib/fast.rb
+++ b/lib/fast.rb
@@ -89,7 +89,7 @@ module Fast
     # Verify if a given AST matches with a specific pattern
     # @return [Boolean] case matches ast with the current expression
     # @example
-    #   Fast.match?(Fast.ast("1"),"int") # => true
+    #   Fast.match?("int", Fast.ast("1")) # => true
     def match?(pattern, ast, *args)
       Matcher.new(pattern, ast, *args).match?
     end
@@ -215,7 +215,7 @@ module Fast
     #
     # @example
     #   Fast.debug do
-    #      Fast.match?(s(:int, 1), [:int, 1])
+    #      Fast.match?([:int, 1], s(:int, 1))
     #   end
     #  int == (int 1) # => true
     #  1 == 1 # => true
@@ -515,7 +515,7 @@ module Fast
   #
   # @example check comparision of integers that will always return true
   #   ast = Fast.ast("1 == 1") => s(:send, s(:int, 1), :==, s(:int, 1))
-  #   Fast.match?(ast, "(send $(int _) == \1)") # => [s(:int, 1)]
+  #   Fast.match?("(send $(int _) == \1)", ast) # => [s(:int, 1)]
   class FindWithCapture < Find
     attr_writer :previous_captures
 
@@ -539,10 +539,10 @@ module Fast
   # Use `%1` in the expression and the Matcher#prepare_arguments will
   # interpolate the argument in the expression.
   # @example interpolate the node value 1
-  #   Fast.match?(Fast.ast("1"), "(int %1)", 1) # => true
-  #   Fast.match?(Fast.ast("1"), "(int %1)", 2) # => false
+  #   Fast.match?("(int %1)", Fast.ast("1"), 1) # => true
+  #   Fast.match?("(int %1)", Fast.ast("1"), 2) # => false
   # @example interpolate multiple arguments
-  #   Fast.match?(Fast.ast("1"), "(%1 %2)", :int, 1) # => true
+  #   Fast.match?("(%1 %2)", Fast.ast("1"), :int, 1) # => true
   class FindFromArgument < Find
     attr_writer :arguments
 

--- a/lib/fast/cli.rb
+++ b/lib/fast/cli.rb
@@ -106,8 +106,6 @@ module Fast
 
       @files = [*@files].reject { |arg| arg.start_with?('-') }
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
     # Run a new command line interface digesting the arguments
     def self.run!(argv)
@@ -149,14 +147,10 @@ module Fast
                 report(result, file)
               end
             end
-          rescue StandardError
-            debug "Ops! An error occurred trying to search in #{expression.inspect} in #{file}", $ERROR_INFO, $ERROR_POSITION
-            []
           end
         end
       end
     end
-
 
     # @return [Boolean] true when "-d" or "--debug" option is passed
     def debug_mode?

--- a/lib/fast/cli.rb
+++ b/lib/fast/cli.rb
@@ -41,10 +41,20 @@ module Fast
   end
 
   # Command Line Interface for Fast
-  class Cli
+  class Cli # rubocop:disable Metrics/ClassLength
     attr_reader :pattern, :show_sexp, :pry, :from_code, :similar, :help
     def initialize(args)
-      @opt = OptionParser.new do |opts|
+      args = replace_args_with_shortcut(args) if args.first&.start_with?('.')
+
+      @pattern, *@files = args.reject { |arg| arg.start_with? '-' }
+
+      option_parser.parse! args
+
+      @files = [*@files].reject { |arg| arg.start_with?('-') }
+    end
+
+    def option_parser # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      @option_parser ||= OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
         opts.banner = 'Usage: fast expression <files> [options]'
         opts.on('-d', '--debug', 'Debug fast engine') do
           @debug = true
@@ -64,6 +74,7 @@ module Fast
 
         opts.on('--pry', 'Jump into a pry session with results') do
           @pry = true
+          require 'pry'
         end
 
         opts.on('-c', '--code', 'Create a pattern from code example') do
@@ -89,22 +100,16 @@ module Fast
           @help = true
         end
       end
+    end
 
-      if args.first&.start_with?('.') # shortcut! :tada:
-        shortcut = find_shortcut args.first[1..-1]
-        if shortcut.single_run_with_block?
-          shortcut.run
-          exit
-        else
-          args = args.one? ? shortcut.args : shortcut.merge_args(args[1..-1])
-        end
+    def replace_args_with_shortcut(args)
+      shortcut = find_shortcut args.first[1..-1]
+      if shortcut.single_run_with_block?
+        shortcut.run
+        exit
+      else
+        args.one? ? shortcut.args : shortcut.merge_args(args[1..-1])
       end
-
-      @pattern, *@files = args.reject { |arg| arg.start_with? '-' }
-
-      @opt.parse! args
-
-      @files = [*@files].reject { |arg| arg.start_with?('-') }
     end
 
     # Run a new command line interface digesting the arguments
@@ -116,7 +121,7 @@ module Fast
     # Show help or search for node patterns
     def run!
       if @help || @files.empty? && @pattern.nil?
-        puts @opt.help
+        puts option_parser.help
       else
         search
       end
@@ -133,22 +138,22 @@ module Fast
     # prints all the results.
     def search
       if debug_mode?
-        Fast.debug { Fast.search_all(expression, @files) }
+        Fast.debug { execute_search }
       else
-        begin
-          method_name = @captures ? :capture_all : :search_all
-          Fast.public_send(method_name, expression, @files).each do |file, results|
-            results = [results] unless results.is_a?(Array)
-            results.each do |result|
-              if @pry
-                require 'pry'
-                binding.pry
-              else
-                report(result, file)
-              end
-            end
+        execute_search do |file, results|
+          results.each do |result|
+            binding.pry if @pry # rubocop:disable Lint/Debugger
+            report(result, file)
           end
         end
+      end
+    end
+
+    def execute_search
+      method_name = @captures ? :capture_all : :search_all
+      Fast.public_send(method_name, expression, @files).each do |file, results|
+        results = [results] unless results.is_a?(Array)
+        yield file, results
       end
     end
 

--- a/lib/fast/experiment.rb
+++ b/lib/fast/experiment.rb
@@ -287,7 +287,7 @@ module Fast
 
     # @return [Array<Astrolabe::Node>]
     def search_cases
-      Fast.search(@ast, experiment.expression) || []
+      Fast.search(experiment.expression, @ast) || []
     end
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -297,7 +297,7 @@ module Fast
     # @return [void]
     def partial_replace(*indices)
       replacement = experiment.replacement
-      new_content = Fast.replace_file @file, experiment.expression do |node, *captures|
+      new_content = Fast.replace_file experiment.expression, @file do |node, *captures|
         if indices.nil? || indices.empty? || indices.include?(match_index)
           if replacement.parameters.length == 1
             instance_exec node, &replacement

--- a/spec/fast/cli_spec.rb
+++ b/spec/fast/cli_spec.rb
@@ -16,26 +16,19 @@ RSpec.describe Fast::Cli do
       let(:args) { %w[def lib/fast.rb] }
 
       its(:pattern) { is_expected.to eq('def') }
-
-      its(:files) { is_expected.to eq(['lib/fast.rb']) }
     end
 
     context 'with expression and folders' do
       let(:args) { %w[def lib/fast spec/fast] }
 
       its(:pattern) { is_expected.to eq('def') }
-
-      its(:files) do
-        is_expected.to include('lib/fast/cli.rb')
-        is_expected.to include('spec/fast/cli_spec.rb')
-      end
     end
 
     context 'with -c to search from code and file' do
       let(:args) { %w[match? lib/fast.rb -c] }
 
       its(:pattern) { is_expected.to eq('(send nil :match?)') }
-      its(:files) { is_expected.to eq(['lib/fast.rb']) }
+      its(:from_code) { is_expected.to be_truthy }
     end
 
     context 'with --pry' do
@@ -126,7 +119,6 @@ RSpec.describe Fast::Cli do
         end
 
         its(:pattern) { is_expected.to eq('(casgn nil _ (str _))') }
-        its(:files) { is_expected.to eq(['lib/fast/version.rb']) }
 
         it 'uses the predefined values from the shortcut' do
           expect { cli.run! }.to output(highlight(<<~RUBY)).to_stdout
@@ -140,7 +132,7 @@ RSpec.describe Fast::Cli do
         let(:args) { ['(casgn nil _ (str $_))', 'lib/fast/version.rb', '--captures', '--headless'] }
 
         it 'prints only captured scope' do
-          expect { cli.run! }.to output(highlight(Fast::VERSION + "\n")).to_stdout
+          expect { cli.run! }.to output(highlight(Fast::VERSION) + "\n").to_stdout
         end
       end
     end

--- a/spec/fast/shortcut_spec.rb
+++ b/spec/fast/shortcut_spec.rb
@@ -34,7 +34,7 @@ describe Fast::Shortcut do
   context 'when a block is given' do
     subject(:bump) do
       Fast.shortcut :bump_version do
-        rewrite_file('sample_version.rb', '(casgn nil VERSION (str _)') do |node|
+        rewrite_file('(casgn nil VERSION (str _)', 'sample_version.rb') do |node|
           target = node.children.last.loc.expression
           replace(target, '0.0.2'.inspect)
         end


### PR DESCRIPTION
I struggled a lot to remind the pattern as second or first parameter of all
methods and it was a mess between `match?`, `search`, `rewrite`, `replace`, etc.

Now all methods follow the same interface: the expression is the first argument.