### PR TITLE
Add `fast --parallel` to parallelize the process

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ The CLI tool takes the following flags
 - Use `--pry` to jump debugging the first result with pry
 - Use `-c` to search from code example
 - Use `-s` to search similar code
+- Use `-p` or `--parallel` to parallelize the search
 
 ### Define your `Fastfile`
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -11,6 +11,7 @@ $ fast '(def match?)' lib/fast.rb
 - Use `--pry` to jump debugging the first result with pry
 - Use `-c` to search from code example
 - Use `-s` to search similar code
+- Use `-p` to or `--parallel` to use multi core search
 
 ## `--pry`
 

--- a/fast.gemspec
+++ b/fast.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'astrolabe'
   spec.add_dependency 'coderay'
+  spec.add_dependency 'parallel'
   spec.add_dependency 'parser'
   spec.add_dependency 'pry'
 

--- a/spec/fast/cli_spec.rb
+++ b/spec/fast/cli_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe Fast::Cli do
       its(:pry) { is_expected.to be_truthy }
     end
 
+    context 'with --parallel' do
+      let(:args) { %w[--parallel] }
+
+      it { is_expected.to be_parallel }
+
+      context 'with -p as shortcut' do
+        let(:args) { %w[-p] }
+
+        it { is_expected.to be_parallel }
+      end
+
+      context 'with -p and --pry' do
+        let(:args) { %w[--parallel --pry] }
+
+        it 'raises incompatible error' do
+          expect { cli.run! }.to raise_error(RuntimeError, 'pry and parallel options are incompatible :(')
+        end
+      end
+    end
+
     context 'with --debug' do
       let(:args) { %w[--debug] }
 

--- a/spec/fast_spec.rb
+++ b/spec/fast_spec.rb
@@ -490,7 +490,7 @@ RSpec.describe Fast do
   describe '.capture_all' do
     it 'allow search multiple files in the same time' do
       results = described_class.capture_all('(casgn nil VERSION (str $_))', ['lib/fast/version.rb'])
-      expect(results).to eq('lib/fast/version.rb' => Fast::VERSION)
+      expect(results).to eq('lib/fast/version.rb' => [Fast::VERSION])
     end
 
     context 'with empty file' do
@@ -517,7 +517,7 @@ RSpec.describe Fast do
 
   describe '.capture' do
     it 'single element' do
-      expect(described_class.capture('(lvasgn _ (int $_))', code['a = 1'])).to eq(1)
+      expect(described_class.capture('(lvasgn _ (int $_))', code['a = 1'])).to eq([1])
     end
 
     it 'array elements' do
@@ -525,11 +525,11 @@ RSpec.describe Fast do
     end
 
     it 'nodes' do
-      expect(described_class.capture('(lvasgn _ $(int _))', code['a = 1'])).to eq(code['1'])
+      expect(described_class.capture('(lvasgn _ $(int _))', code['a = 1'])).to eq([code['1']])
     end
 
     it 'multiple nodes' do
-      expect(described_class.capture('$(lvasgn _ (int _))', code['a = 1'])).to eq(code['a = 1'])
+      expect(described_class.capture('$(lvasgn _ (int _))', code['a = 1'])).to eq([code['a = 1']])
     end
   end
 


### PR DESCRIPTION
Just adding parallelization since for complex and huge projects it's too much to delay.

My benchmarks shows like same search sample from 183 secs to 48 on a big project.