### PR TITLE
Fix broken link to "RuboCop Node Pattern"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The current version of Fast covers the following token elements:
     to build custom rules.
 - `.<method-name>` - will call `<method-name>` from the `node`
 
-The syntax is inspired by the [RuboCop Node Pattern](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/node_pattern.rb).
+The syntax is inspired by the [RuboCop Node Pattern](https://github.com/rubocop-hq/rubocop-ast/blob/master/lib/rubocop/ast/node_pattern.rb).
 
 ## Installation
 


### PR DESCRIPTION
Hi, thanks a lot for your awesome talk in RubyKaigi Takeout 2020!
When I read the README, I found the broken link. So, I've opened this pull request.

`https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/node_pattern.rb` is 404 not found now.
Instead, I think `https://github.com/rubocop-hq/rubocop-ast/blob/master/lib/rubocop/ast/node_pattern.rb` is correct now.