### PR TITLE
Introduce `fast .intro` and `fast .walk`

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -35,3 +35,57 @@ Fast.shortcut :bump_version do
     replace(target, "'#{pieces.join('.')}'")
   end
 end
+
+# List all shortcut with comments
+Fast.shortcut :shortcuts do
+  fast_files.each do |file|
+    lines = File.readlines(file).map { |line| line.chomp.gsub(/\s*#/, '').strip }
+    result = capture_file('(send _ :shortcut $(sym _) ...)', file)
+    result = [result] unless result.is_a? Array
+    result.each do |capture|
+      target = capture.loc.expression
+      puts "fast .#{target.source[1..].ljust(30)} # #{lines[target.line - 2]}"
+    end
+  end
+end
+
+# Use to walkthrough the docs files with fast examples
+# fast .intro
+Fast.shortcut :intro do
+  ARGV << File.join(File.dirname(__FILE__), 'docs', 'walkthrough.md')
+
+  Fast.shortcuts[:walk].run
+end
+
+# Useful for `fast .walk file.md` but not required by the library.
+private def require_or_install_tty_md
+  require 'tty-markdown'
+rescue LoadError
+  puts 'Installing tty-markdown gem to better engage you :)'
+  Gem.install('tty-markdown')
+  puts 'Done! Now, back to our topic \o/'
+  system('clear')
+  retry
+end
+
+# Interactive command line walkthrough
+# fast .walk docs/walkthrough.md
+Fast.shortcut :walk do
+  require_or_install_tty_md
+  file = ARGV.last
+  execute = ->(line) { system(line) }
+  walk = ->(line) { line.each_char { |c| sleep(0.02) and print(c) } }
+  File.readlines(file).each do |line|
+    case line
+    when /^fast /
+      walk[line]
+      execute[line]
+    when /^\$ /
+      walk[line]
+      execute[line[2..]]
+    when /^!{3}\s/ # Skip warnings that are only for web tutorials
+    else
+      walk[TTY::Markdown.parse(line)]
+    end
+  end
+end

--- a/Fastfile
+++ b/Fastfile
@@ -58,7 +58,8 @@ Fast.shortcut :intro do
 end
 
 # Useful for `fast .walk file.md` but not required by the library.
-private def require_or_install_tty_md
+private
+def require_or_install_tty_md
   require 'tty-markdown'
 rescue LoadError
   puts 'Installing tty-markdown gem to better engage you :)'
@@ -83,7 +84,8 @@ Fast.shortcut :walk do
     when /^\$ /
       walk[line]
       execute[line[2..]]
-    when /^!{3}\s/ # Skip warnings that are only for web tutorials
+    when /^!{3}\s/
+      # Skip warnings that are only for web tutorials
     else
       walk[TTY::Markdown.parse(line)]
     end

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,0 +1,135 @@
+# Fast walkthrough
+
+!!! note "This is the main interactive tutorial we have on `fast`. If you're reading it on the web, please consider also try it in the command line: `fast .intro` in the terminal to get a rapid pace on reading and testing on your own computer."
+
+The objective here is give you some insights about how to use `ffast` gem in the
+command line.
+
+Let's start finding the main `fast.rb` file for the fast library:
+
+```
+$ gem which fast
+```
+
+And now, let's combine the previous expression that returns the path to the file
+and take a quick look into the methods `match?` in the file using a regular grep:
+
+```
+$ grep "def match\?" $(gem which fast)
+```
+
+Boring results, no? The code here is not easy to digest because we just see a
+fragment of the code block that we want.
+Let's make it a bit more advanced with `grep -rn` to file name and line number:
+
+```
+$ grep -rn "def match\?" $(gem which fast)
+```
+
+Still hard to understand the scope of the search.
+
+That's why fast exists! Now, let's take a look on how a method like this looks
+like from the AST perspective. Let's use `ruby-parse` for it:
+
+```
+$ ruby-parse -e "def match?(node); end"
+```
+
+Now, let's make the same search with `fast` node pattern:
+
+```
+fast "(def match?)" $(gem which fast)
+```
+
+Wow! in this case you got all the `match?` methods, but you'd like to go one level upper
+and understand the classes that implements the method with a single node as
+argument. Let's first use `^` to jump into the parent:
+
+```
+fast "^(def match?)" $(gem which fast)
+```
+
+As you can see it still prints some `match?` methods that are not the ones that
+we want, so, let's add a filter by the argument node `(args (arg node))`:
+
+```
+fast "(def match? (args (arg node)))" $(gem which fast)
+```
+
+Now, it looks closer to have some understanding of the scope, filtering only
+methods that have the name `match?` and receive `node` as a parameter.
+
+Now, let's do something different and find all methods that receives a `node` as
+an argument:
+
+```
+fast "(def _ (args (arg node)))" $(gem which fast)
+```
+
+Looks like almost all of them are the `match?` and we can also skip the `match?`
+methods negating the expression prefixing with `!`:
+
+```
+fast "(def !match? (args (arg node)))" $(gem which fast)
+```
+
+Let's move on and learn more about node pattern with the RuboCop project:
+
+```
+$ VISUAL=echo gem open rubocop
+```
+
+RuboCop contains `def_node_matcher` and `def_node_search`. Let's make a search
+for both method names wrapping the query with `{}` selector:
+
+```
+fast "(send nil {def_node_matcher def_node_search})" $(VISUAL=echo gem open rubocop)
+```
+
+As you can see, node pattern is widely adopted in the cops to target code.
+Rubocop contains a few projects with dedicated cops that can help you learn
+more.
+
+## How to automate refactor using AST
+
+Moving towards to the code automation, the next step after finding some target code
+is refactor and change the code behavior.
+
+Let's imagine that we already found some code that we want to edit or remove. If
+we get the AST we can also cherry-pick any fragment of the expression to be
+replaced. As you can imagine, RuboCop also benefits from automatic refactoring
+offering the `--autocorrect` option.
+
+All the hardcore algorithms are in the [parser](https://github.com/whitequark/parser)
+rewriter, but we can find a lot of great examples on RuboCop project searching
+for the `autocorrect` method.
+
+```
+fast "(def autocorrect)" $(VISUAL=echo gem open rubocop)
+```
+
+Look that most part of the methods are just returning a lambda with a
+corrector. Now, let's use the `--ast` to get familiar with the tree details for the
+implementation:
+
+```
+fast --ast "(def autocorrect)" $(VISUAL=echo gem open rubocop)/lib/rubocop/cop/style
+```
+
+As we can see, we have a `(send (lvar corrector))` that is the interface that we
+can get the most interesting calls to overwrite files:
+
+```
+fast "(send (lvar corrector)" $(VISUAL=echo gem open rubocop)
+```
+
+
+## That is all for now!
+
+I hope you enjoyed to learn by example searching with fast. If you like it,
+please [star the project](https://github.com/jonatas/fast/)!
+
+You can also build your own tutorials simply using markdown files like I did
+here, you can find this tutorial [here](https://github.com/jonatas/fast/tree/master/docs/walkthrough.md).
+
+

--- a/fast.gemspec
+++ b/fast.gemspec
@@ -20,6 +20,24 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
 
+  spec.post_install_message = <<~THANKS
+
+    ==========================================================
+    Yay! Thanks for installing
+
+       ___       __  ___
+      |__   /\  /__`  |
+      |    /~~\ .__/  |
+
+    To interactive learn about the gem in the terminal use:
+
+    fast .intro
+
+    More docs at: https://jonatas.github.io/fast/
+    ==========================================================
+
+  THANKS
+
   spec.bindir        = 'bin'
   spec.executables   = %w[fast fast-experiment]
   spec.require_paths = %w[lib experiments]

--- a/fast.gemspec
+++ b/fast.gemspec
@@ -54,10 +54,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rspec-its', '~> 1.2'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'simplecov', '~> 0.10', '< 0.18'
+  spec.add_development_dependency 'simplecov'
 end

--- a/lib/fast/shortcut.rb
+++ b/lib/fast/shortcut.rb
@@ -7,7 +7,12 @@ module Fast
     # 1. Current directory that the command is being runned
     # 2. Home folder
     # 3. Using the `FAST_FILE_DIR` variable to set an extra folder
-    LOOKUP_FAST_FILES_DIRECTORIES = [Dir.pwd, ENV['HOME'], ENV['FAST_FILE_DIR']].freeze
+    LOOKUP_FAST_FILES_DIRECTORIES = [
+      Dir.pwd,
+      ENV['HOME'],
+      ENV['FAST_FILE_DIR'],
+      File.join(File.dirname(__FILE__), '..', '..')
+    ].compact.map(&File.method(:expand_path)).uniq.freeze
 
     # Store predefined searches with default paths through shortcuts.
     # define your Fastfile in you root folder or

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ markdown_extensions:
       permalink: true
 nav:
   - Introduction: index.md
+  - Walkthrough: walkthrough.md
   - Syntax: syntax.md
   - Command Line: command_line.md
   - Experiments: experiments.md

--- a/spec/fast/cli_spec.rb
+++ b/spec/fast/cli_spec.rb
@@ -114,8 +114,20 @@ RSpec.describe Fast::Cli do
       it 'prints file with line number' do
         expect { cli.run! }.to output(highlight(<<~RUBY)).to_stdout
           # lib/fast/version.rb:4
-          VERSION = '#{Fast::VERSION}'
+          \s\sVERSION = '#{Fast::VERSION}'
         RUBY
+      end
+
+      context 'when the code is not from the beginning of the line' do
+        let(:args) { %w[str lib/fast/version.rb] }
+
+        it 'prints fragment of line' do
+          cli.run!
+          expect { cli.run! }.to output(highlight(<<~RUBY)).to_stdout
+            # lib/fast/version.rb:4
+            '#{Fast::VERSION}'
+          RUBY
+        end
       end
 
       context 'with args to print ast' do
@@ -143,7 +155,7 @@ RSpec.describe Fast::Cli do
         it 'uses the predefined values from the shortcut' do
           expect { cli.run! }.to output(highlight(<<~RUBY)).to_stdout
             # lib/fast/version.rb:4
-            VERSION = '#{Fast::VERSION}'
+              VERSION = '#{Fast::VERSION}'
           RUBY
         end
       end

--- a/spec/fast/experiment_spec.rb
+++ b/spec/fast/experiment_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Fast::Experiment do
       it { expect(experiment_file.experimental_filename(1)).to include('experiment_1') }
     end
 
-    describe '#replace' do
+    describe '#replace', only: :local do
       it 'replace only first case' do
         expect(experiment_file.partial_replace(1)).to eq(<<~RUBY)
           let(:user) { build_stubbed(:user) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,12 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.around(:example, only: :local) do |example|
+    if ENV['TRAVIS']
+      example.skip
+    else
+      example.run
+    end
+  end
 end


### PR DESCRIPTION
# Codebase walkthrough


I developed fast because of the possibility of jumping straight into the code that I'd like to focus on or analyze a pattern in a large codebase.

I introduced the walkthrough as a new interactive learning way that can help us to build easy onboarding for people jumping into a new Ruby project. In the walkthrough, I navigate into the basis of what I used to build fast, I think the same can be done to introduce new concepts for the codebase or even keep live documentation pointing straight to the focus based on real code search and not old or permalink versions. 

# How to test

Checkout repo with actual changes:

```
git clone git@github.com:jonatas/fast.git
cd fast
git fetch origin
git checkout walk-shortcut
rake install
```

Then try:

```
fast .intro
```

If you can also build your own tutorials and use `fast .walk` to run it.

Example of the markdown file:

```
fast .walk docs/walkthrough.md
```
[![asciicast](https://asciinema.org/a/379871.svg)](https://asciinema.org/a/379871)

## Ideas

- [ ] Introduce some `[ok]` syntax to make the script stop and force the user to hit enter before continue
- [ ] Introduce some `--limit` to not show all results and overwhelm the person learning
 
The same tutorial is also part of the official documentation but not exporting the data from my local computer:

https://jonatas.github.io/fast/walkthrough/
